### PR TITLE
CON-3537 relax restriction on ActiveSupport, add CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,4 @@
+# v0.13.0
+
+* Relax ActiveSupport version restriction. Allows use of
+  conjur-policy-parser with a Rails 5 application.

--- a/conjur-policy-parser.gemspec
+++ b/conjur-policy-parser.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "safe_yaml"
-  spec.add_dependency "activesupport", "~> 4.2"
+  spec.add_dependency "activesupport", ">= 4.2"
 
   spec.add_development_dependency "bundler", "~> 1.11"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
Version has already been bumped, v0.13.0 hasn't been pushed to rubygems yet.
