### PR TITLE
Webservice is a role

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@
 /pkg/
 /spec/reports/
 /tmp/
+.history
+

--- a/lib/conjur/policy/types/records.rb
+++ b/lib/conjur/policy/types/records.rb
@@ -172,11 +172,6 @@ module Conjur
         include ActsAsRole
       end
 
-      class CredentialFactory < Record
-        include ActsAsResource
-        include ActsAsRole
-      end
-      
       class Variable < Record
         include ActsAsResource
         
@@ -194,6 +189,7 @@ module Conjur
       
       class Webservice < Record
         include ActsAsResource
+        include ActsAsRole
       end
       
       class HostFactory < Record

--- a/lib/conjur/policy/types/records.rb
+++ b/lib/conjur/policy/types/records.rb
@@ -171,6 +171,11 @@ module Conjur
         include ActsAsResource
         include ActsAsRole
       end
+
+      class CredentialFactory < Record
+        include ActsAsResource
+        include ActsAsRole
+      end
       
       class Variable < Record
         include ActsAsResource

--- a/lib/conjur/policy/yaml/loader.rb
+++ b/lib/conjur/policy/yaml/loader.rb
@@ -42,7 +42,7 @@ module Conjur
           protected
           
           def parse_includes records, dirname
-            records.each_with_index do |record, idx|
+            Array(records).each_with_index do |record, idx|
               if record.is_a?(Array)
                 parse_includes record, dirname
               elsif record.is_a?(Types::Policy)


### PR DESCRIPTION
Adds "role" nature to the `webservice` object, so that web services can have permissions.

This is used by the Credential Factory feature to permit a webservice to access the Variables which it needs to e.g. call AWS Security Token Service.
 