### PR TITLE
Update tests to verify against Ruby versions 2.3, 2.4, and 2.5

### DIFF
--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,0 +1,15 @@
+ARG RUBY_VERSION=2.5
+FROM ruby:${RUBY_VERSION}
+
+RUN mkdir /src
+WORKDIR /src
+
+COPY Gemfile Gemfile
+COPY conjur-policy-parser.gemspec conjur-policy-parser.gemspec
+COPY lib/conjur-policy-parser-version.rb lib/conjur-policy-parser-version.rb
+
+# Make sure only one version of bundler is available
+RUN gem uninstall bundler -i /usr/local/lib/ruby/gems/${RUBY_VERSION} bundler || true && \
+  gem uninstall bundler -aIx || true && \
+  gem install bundler -v 1.11.2 && \
+  bundle install

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-#ruby=ruby-2.2.5
+#ruby=ruby-2.5
 #ruby-gemset=conjur-policy-parser
 
 # Specify your gem's dependencies in conjur-policy-parser.gemspec

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,10 +9,32 @@ pipeline {
   }
 
   stages {
-    stage('Test') {
+    stage('Test 2.3') {
+      environment {
+        RUBY_VERSION = '2.3.5'
+      }
       steps {
         sh './test.sh'
+        junit 'spec/reports/*.xml'
+      }
+    }
 
+    stage('Test 2.4') {
+      environment {
+        RUBY_VERSION = '2.4.2'
+      }
+      steps {
+        sh './test.sh'
+        junit 'spec/reports/*.xml'
+      }
+    }
+
+    stage('Test 2.5') {
+      environment {
+        RUBY_VERSION = '2.5.1'
+      }
+      steps {
+        sh './test.sh'
         junit 'spec/reports/*.xml'
       }
     }

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -1,6 +1,3 @@
 #!/bin/bash -ex
 
-cd /src/conjur-policy-parser
-bundle
-
 bundle exec rake jenkins || true

--- a/conjur-policy-parser.gemspec
+++ b/conjur-policy-parser.gemspec
@@ -28,4 +28,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "ci_reporter_rspec"
   spec.add_development_dependency "simplecov"
   spec.add_development_dependency "pry"
+  spec.add_development_dependency "deepsort"
 end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,20 @@
+version: "3"
+services:
+  dev:
+    image: ruby:2.5
+    working_dir: /src
+    volumes: 
+      - .:/src
+
+  test:
+    image: policy-parser-test:${RUBY_VERSION}
+    build:
+      context: .
+      dockerfile: Dockerfile.test
+      args:
+        RUBY_VERSION: ${RUBY_VERSION}
+    entrypoint: ci/test.sh
+    environment:
+      - DEBUG
+    volumes:
+      - .:/src

--- a/spec/resolver_spec.rb
+++ b/spec/resolver_spec.rb
@@ -17,7 +17,9 @@ describe Resolver do
   
   shared_examples_for "verify resolver" do
     it "matches expected YAML" do
-      expect(subject).to eq(fixture['expectation'])
+      expected = sorted_yaml fixture['expectation'] 
+      actual = sorted_yaml subject
+      expect(actual).to eq(expected)
     end
   end
 

--- a/spec/sorted_yaml.rb
+++ b/spec/sorted_yaml.rb
@@ -1,0 +1,8 @@
+require 'yaml'
+require 'deepsort'
+
+module SortedYAML
+  def sorted_yaml yaml
+    YAML.load(yaml).deep_sort_by {|obj| obj.to_s}
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,3 +12,7 @@ if ENV['DEBUG']
   Conjur::PolicyParser::YAML::Handler.logger.level = Logger::DEBUG 
 end
 
+require 'sorted_yaml.rb'
+RSpec.configure do |c|
+  c.include SortedYAML
+end

--- a/spec/yaml_loader_spec.rb
+++ b/spec/yaml_loader_spec.rb
@@ -5,7 +5,9 @@ describe Conjur::PolicyParser::YAML::Loader do
   shared_examples_for "round-trip dsl" do |example|
     let(:filename) { "spec/round-trip/yaml/#{example}.yml" }
     it "#{example}.yml" do
-      expect(Conjur::PolicyParser::YAML::Loader.load_file(filename).to_yaml).to eq(File.read("spec/round-trip/yaml/#{example}.expected.yml"))
+      expected = sorted_yaml File.read("spec/round-trip/yaml/#{example}.expected.yml")
+      actual = sorted_yaml Conjur::PolicyParser::YAML::Loader.load_file(filename).to_yaml
+      expect(actual).to eq(expected)
     end
   end
 

--- a/test.sh
+++ b/test.sh
@@ -1,27 +1,23 @@
 #!/bin/bash -ex
 
-CONJUR_VERSION=${CONJUR_VERSION:-"4.9"}
-DOCKER_IMAGE=${DOCKER_IMAGE:-"registry.tld/conjur-appliance-cuke-master:$CONJUR_VERSION-stable"}
-NOKILL=${NOKILL:-"0"}
-PULL=${PULL:-"1"}
+: ${RUBY_VERSION=2.5.1}
 
-if [ -z "$CONJUR_CONTAINER" ]; then
-	if [ "$PULL" == "1" ]; then
-	    docker pull $DOCKER_IMAGE
-	fi
-	
-	cid=$(docker run --privileged -d -v ${PWD}:/src/conjur-policy-parser $DOCKER_IMAGE)
-	function finish {
-    	if [ "$NOKILL" != "1" ]; then
-			docker rm -f ${cid}
-		fi
-	}
-	trap finish EXIT
-	
-	>&2 echo "Container id:"
-	>&2 echo $cid
-else
-	cid=${CONJUR_CONTAINER}
-fi
+# My local RUBY_VERSION is set to ruby-#.#.# so this allows running locally.
+RUBY_VERSION=$(cut -d '-' -f 2 <<< $RUBY_VERSION)
 
-docker exec -i ${cid} /src/conjur-policy-parser/ci/test.sh
+main() {
+  build
+  run_tests
+}
+
+# internal functions
+
+build() {
+  docker-compose build --pull
+}
+
+run_tests() {
+  docker-compose run test "$@"
+}
+
+main


### PR DESCRIPTION
#### Background
Ruby 2.5 removed the deprecated `to_yaml_properties` method, causing most of the rspec tests to fail.

#### What does this PR do?
This PR sorts the parsed YAML data structures during test comparison to make YAML order not be a cause for test failure. It also updates the Jenkins pipeline to test against maintained ruby versions (2.3-2.5)

#### Jenkins Build
https://jenkins.conjur.net/job/conjurinc--conjur-policy-parser/job/test_2_5/