### PR TITLE
CIDR Authentication Restriction for Users and Hosts

### DIFF
--- a/lib/conjur/policy/types/records.rb
+++ b/lib/conjur/policy/types/records.rb
@@ -143,11 +143,12 @@ module Conjur
 
         attribute :uidnumber, kind: :integer, singular: true, dsl_accessor: true
         attribute :public_key, kind: :string, dsl_accessor: true
+        attribute :restricted_to, kind: :string, singular: true, dsl_accessor: true
 
         def id_attribute; 'login'; end
         
         def custom_attribute_names
-          [ :uidnumber, :public_key ]
+          [ :uidnumber, :public_key, :restricted_to ]
         end
       end
       
@@ -165,6 +166,12 @@ module Conjur
       class Host < Record
         include ActsAsResource
         include ActsAsRole
+
+        attribute :restricted_to, kind: :string, singular: true, dsl_accessor: true
+
+        def custom_attribute_names
+          [ :restricted_to ]
+        end
       end
       
       class Layer < Record

--- a/lib/conjur/policy/types/records.rb
+++ b/lib/conjur/policy/types/records.rb
@@ -143,7 +143,7 @@ module Conjur
 
         attribute :uidnumber, kind: :integer, singular: true, dsl_accessor: true
         attribute :public_key, kind: :string, dsl_accessor: true
-        attribute :restricted_to, kind: :string, singular: true, dsl_accessor: true
+        attribute :restricted_to, kind: :string, dsl_accessor: true
 
         def id_attribute; 'login'; end
         
@@ -167,7 +167,7 @@ module Conjur
         include ActsAsResource
         include ActsAsRole
 
-        attribute :restricted_to, kind: :string, singular: true, dsl_accessor: true
+        attribute :restricted_to, kind: :string, dsl_accessor: true
 
         def custom_attribute_names
           [ :restricted_to ]

--- a/spec/round-trip/yaml/restricted_to.expected.yml
+++ b/spec/round-trip/yaml/restricted_to.expected.yml
@@ -5,3 +5,9 @@
 - !user
   id: alice
   restricted_to: 192.168.0.0/16
+
+- !user
+  id: bob
+  restricted_to: 
+    - 192.168.0.1/16
+    - 192.168.0.2/16

--- a/spec/round-trip/yaml/restricted_to.expected.yml
+++ b/spec/round-trip/yaml/restricted_to.expected.yml
@@ -1,0 +1,7 @@
+- !host
+  id: app
+  restricted_to: 192.168.0.0
+
+- !user
+  id: alice
+  restricted_to: 192.168.0.0/16

--- a/spec/round-trip/yaml/restricted_to.yml
+++ b/spec/round-trip/yaml/restricted_to.yml
@@ -5,3 +5,7 @@
 - !user
   id: alice
   restricted_to: 192.168.0.0/16
+
+- !user
+  id: bob
+  restricted_to: [ 192.168.0.1/16, 192.168.0.2/16 ]

--- a/spec/round-trip/yaml/restricted_to.yml
+++ b/spec/round-trip/yaml/restricted_to.yml
@@ -1,0 +1,7 @@
+- !host
+  id: app
+  restricted_to: 192.168.0.0
+
+- !user
+  id: alice
+  restricted_to: 192.168.0.0/16

--- a/spec/yaml_loader_spec.rb
+++ b/spec/yaml_loader_spec.rb
@@ -42,6 +42,7 @@ describe Conjur::PolicyParser::YAML::Loader do
   it_should_behave_like 'round-trip dsl', 'org'
   it_should_behave_like 'round-trip dsl', 'include'
   it_should_behave_like 'round-trip dsl', 'policy-empty-body'
+  it_should_behave_like 'round-trip dsl', 'restricted_to'
 
   it_should_behave_like 'error message', 'unrecognized-type'
   it_should_behave_like 'error message', 'incorrect-type-for-field-1'


### PR DESCRIPTION
This PR adds support for setting a `restricted_to` CIDR for authentication of User and Host resource roles. 

This is PR 1 of 2. Closes https://github.com/cyberark/conjur/issues/601

Part 2 is here: https://github.com/cyberark/conjur/pull/616

Jenkins build:
https://jenkins.conjur.net/job/conjurinc--conjur-policy-parser/job/restricted_to_cidr/