### PR TITLE
Fix duplicate members validation in policy yaml

### DIFF
--- a/lib/conjur/policy/yaml/handler.rb
+++ b/lib/conjur/policy/yaml/handler.rb
@@ -202,7 +202,7 @@ module Conjur
           
           def initialize parent, anchor, type
             super parent, anchor
-            
+            @existing_members = Set.new()
             @record = type.new
           end
   
@@ -229,6 +229,11 @@ module Conjur
   
           # Begins a new map entry.
           def scalar value, tag, quoted, anchor
+            if @existing_members.include?(value)
+              raise "Duplicate attribute of type #{value}"
+            else
+              @existing_members.add(value);
+            end
             value = scalar_value(value, tag, quoted, type)
             MapEntry.new(self, anchor, @record, value).tap do |h|
               h.push_handler


### PR DESCRIPTION
#### What does this PR do? Is there any background context you want to provide?
This PR added validation on policy yaml file upon loading it to conjur
Now members with same name under each hierarchy level are disallowed

Reconstruction Steps:

1. Run Conjur
2. Enter Conjur CLI
3. Create policy.yaml file with the following content:
```
- !host host1
- !host host2

- !variable secret
- !group secret-consumers

- !permit
  role: !group secret-consumers
  resource: !variable secret
  privilege: [ read, execute ]

- !grant
  role: !group secret-consumers
  member: !host host1
  member: !host host2
```

4. Load policy to the system using the following command:
conjur policy load root policy.yaml

5. The expected result should be failure of loading policy with an appropriate error message describing that there are duplicate entries in policy and mentioning which of them
The error message is: "Duplicate attribute on type member"

#### What ticket does this PR close?
https://github.com/cyberark/conjur/issues/1263

#### Where should the reviewer start? How should this functionality be validated?
The reviewer should look on the changes in handler.rb file - they implement a new validation
