### PR TITLE
Bump Rake from 10.0 to 12.3.3

### DIFF
--- a/conjur-policy-parser.gemspec
+++ b/conjur-policy-parser.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "activesupport", ">= 4.2"
 
   spec.add_development_dependency "bundler", "~> 1.11"
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "rake", ">= 12.3.3"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "rspec-expectations"
   spec.add_development_dependency "ci_reporter_rspec"


### PR DESCRIPTION
To resolve CVE-2020-8130

Jenkins build: https://jenkins.conjur.net/job/conjurinc--conjur-policy-parser/job/bump-rake-version/